### PR TITLE
feat: barcode lookup tools + OAuth token caching

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,7 +2,7 @@
   "semi": true,
   "trailingComma": "es5",
   "singleQuote": true,
-  "printWidth": 100,
+  "printWidth": 120,
   "tabWidth": 2,
   "useTabs": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.0",
+        "sharp": "^0.34.5",
         "uuid": "^13.0.0",
         "yazio": "^1.0.0",
-        "zod": "^4.2.1"
+        "zod": "^4.2.1",
+        "zxing-wasm": "^3.0.0"
       },
       "bin": {
         "yazio-mcp": "dist/index.js"
@@ -29,6 +31,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -736,6 +748,471 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.25.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.0.tgz",
@@ -834,6 +1311,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1452,6 +1935,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -2958,10 +3450,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3012,6 +3503,50 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3141,6 +3676,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3176,6 +3723,13 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/tsx": {
       "version": "4.20.5",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
@@ -3207,6 +3761,21 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
+      "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -3350,6 +3919,19 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"
+      }
+    },
+    "node_modules/zxing-wasm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.0.0.tgz",
+      "integrity": "sha512-s7ASCPKX+QnH7Y83f4Byxmq/vDzYW7B9m6jMP5S30JGfN2A6WAUn6P3vcBmNguDhPLE6ny2fjTooQVyKBXI1qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "^1.41.5",
+        "type-fest": "^5.4.4"
+      },
+      "peerDependencies": {
+        "@types/emscripten": ">=1.39.6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -49,9 +49,11 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.0",
+    "sharp": "^0.34.5",
     "uuid": "^13.0.0",
     "yazio": "^1.0.0",
-    "zod": "^4.2.1"
+    "zod": "^4.2.1",
+    "zxing-wasm": "^3.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,43 @@
 #!/usr/bin/env node
 
 import { createRequire } from 'node:module';
+import { readFileSync, writeFileSync } from 'node:fs';
+import sharp from 'sharp';
+import { readBarcodesFromImageData } from 'zxing-wasm/reader';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { Yazio } from 'yazio';
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from 'uuid';
+
+const TOKEN_CACHE_PATH = process.env.YAZIO_TOKEN_CACHE_PATH || '/tmp/yazio-token-cache.json';
+
+interface CachedToken {
+  token_type: string;
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  expires_at: number;
+}
+
+function loadCachedToken(): CachedToken | null {
+  try {
+    const token: CachedToken = JSON.parse(readFileSync(TOKEN_CACHE_PATH, 'utf-8'));
+    if (token.access_token && token.expires_at > Date.now()) return token;
+    console.error('⏰ Cached token expired, will re-authenticate');
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function saveCachedToken(token: CachedToken): void {
+  try {
+    writeFileSync(TOKEN_CACHE_PATH, JSON.stringify(token, null, 2), { mode: 0o600 });
+    console.error('💾 Token cached to', TOKEN_CACHE_PATH);
+  } catch (error) {
+    console.error('⚠️ Failed to cache token:', (error as Error).message);
+  }
+}
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json') as { version: string };
@@ -39,22 +72,14 @@ import {
   type SearchByBarcodeInput,
   type ScanBarcodeImageInput,
 } from './schemas.js';
-import type {
-  YazioExerciseOptions,
-  YazioSuggestedProductsOptions,
-  YazioAddWaterIntakeOptions
-} from './types.js';
+import type { YazioExerciseOptions, YazioSuggestedProductsOptions, YazioAddWaterIntakeOptions } from './types.js';
 
 class YazioMcpServer {
   private server: McpServer;
   private yazioClient: Yazio | null = null;
 
   constructor() {
-    this.server = new McpServer({
-      name: 'yazio-mcp',
-      version,
-    });
-
+    this.server = new McpServer({ name: 'yazio-mcp', version });
     this.setupToolHandlers();
     this.setupPromptHandlers();
     this.setupErrorHandling();
@@ -71,42 +96,61 @@ class YazioMcpServer {
       process.exit(1);
     }
 
+    const onRefresh = ({ token }: { token: CachedToken }) => saveCachedToken(token);
+    const cachedToken = loadCachedToken();
+
+    // Try cached token first
+    if (cachedToken) {
+      try {
+        console.error('🔑 Using cached token (expires', new Date(cachedToken.expires_at).toISOString(), ')');
+        this.yazioClient = new Yazio({
+          credentials: { username, password },
+          token: cachedToken,
+          onRefresh,
+        });
+        await this.yazioClient.user.get();
+        console.error('✅ Successfully authenticated with Yazio');
+        this.extendWaterIntakeSupport(this.yazioClient);
+        return;
+      } catch {
+        console.error('⚠️ Cached token failed, re-authenticating...');
+      }
+    }
+
+    // Fresh auth (either no cache or cache failed)
     try {
-      this.yazioClient = new Yazio({
-        credentials: {
-          username,
-          password
-        }
-      });
-      // Test the connection
+      console.error('🔐 Authenticating...');
+      this.yazioClient = new Yazio({ credentials: { username, password }, onRefresh });
       await this.yazioClient.user.get();
-      console.error('✅ Successfully authenticated with Yazio using environment variables');
+      this.trySaveFreshToken();
+      console.error('✅ Successfully authenticated with Yazio');
       this.extendWaterIntakeSupport(this.yazioClient);
     } catch (error) {
       console.error('❌ Failed to authenticate with Yazio:', (error as Error).message);
-      console.error('💡 Please check your YAZIO_USERNAME and YAZIO_PASSWORD environment variables');
       process.exit(1);
     }
   }
 
-  // Extend yazio client package with addWaterIntake method
-  // Discussion https://github.com/juriadams/yazio/issues/3
-  private extendWaterIntakeSupport(client: Yazio): void {
-    // @ts-expect-error - Monkey-patching yazio client to add missing method
-    client.user.addWaterIntake = async (entries: YazioAddWaterIntakeOptions): Promise<void> => {
-      // @ts-expect-error - Accessing internal auth token from yazio client
-      const token = client.auth.token.access_token;
+  private trySaveFreshToken(): void {
+    try {
+      // @ts-expect-error - Accessing internal auth token to cache after fresh login
+      const token = this.yazioClient?.auth?.token;
+      if (token?.access_token) saveCachedToken(token as CachedToken);
+    } catch {
+      /* ignore */
+    }
+  }
 
-      // Access internal HTTP client or make direct fetch call
-      // Try to access base URL from client, fallback to known API URL
+  private extendWaterIntakeSupport(client: Yazio): void {
+    // @ts-expect-error - Monkey-patching yazio client to add missing method (https://github.com/juriadams/yazio/issues/3)
+    client.user.addWaterIntake = async (entries: YazioAddWaterIntakeOptions): Promise<void> => {
+      // @ts-expect-error - Accessing internal auth token
+      const token = client.auth.token.access_token;
       const baseUrl = (client as Yazio & { baseUrl?: string }).baseUrl || 'https://yzapi.yazio.com/v15';
 
       const response = await fetch(`${baseUrl}/user/water-intake`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify(entries),
       });
 
@@ -130,14 +174,9 @@ class YazioMcpServer {
       {
         description: 'Get Yazio user profile information',
         inputSchema: GetUserInfoInputSchema,
-        annotations: {
-          readOnlyHint: true,
-          idempotentHint: true,
-        },
+        annotations: { readOnlyHint: true, idempotentHint: true },
       },
-      async () => {
-        return await this.getUser();
-      }
+      async () => this.getUser()
     );
 
     this.server.registerTool(
@@ -145,14 +184,9 @@ class YazioMcpServer {
       {
         description: 'Get food entries for a specific date',
         inputSchema: GetFoodEntriesInputSchema,
-        annotations: {
-          readOnlyHint: true,
-          idempotentHint: true,
-        },
+        annotations: { readOnlyHint: true, idempotentHint: true },
       },
-      async (args: GetFoodEntriesInput) => {
-        return await this.getUserConsumedItems(args);
-      }
+      async (args: GetFoodEntriesInput) => this.getUserConsumedItems(args)
     );
 
     this.server.registerTool(
@@ -160,14 +194,9 @@ class YazioMcpServer {
       {
         description: 'Get user dietary preferences and restrictions',
         inputSchema: GetDietaryPreferencesInputSchema,
-        annotations: {
-          readOnlyHint: true,
-          idempotentHint: true,
-        },
+        annotations: { readOnlyHint: true, idempotentHint: true },
       },
-      async () => {
-        return await this.getUserDietaryPreferences();
-      }
+      async () => this.getUserDietaryPreferences()
     );
 
     this.server.registerTool(
@@ -175,14 +204,9 @@ class YazioMcpServer {
       {
         description: 'Get user exercise data for a date or date range',
         inputSchema: GetUserExercisesInputSchema,
-        annotations: {
-          readOnlyHint: true,
-          idempotentHint: true,
-        },
+        annotations: { readOnlyHint: true, idempotentHint: true },
       },
-      async (args: GetUserExercisesInput) => {
-        return await this.getUserExercises(args);
-      }
+      async (args: GetUserExercisesInput) => this.getUserExercises(args)
     );
 
     this.server.registerTool(
@@ -190,14 +214,9 @@ class YazioMcpServer {
       {
         description: 'Get user nutrition and fitness goals',
         inputSchema: GetUserGoalsInputSchema,
-        annotations: {
-          readOnlyHint: true,
-          idempotentHint: true,
-        },
+        annotations: { readOnlyHint: true, idempotentHint: true },
       },
-      async () => {
-        return await this.getUserGoals();
-      }
+      async () => this.getUserGoals()
     );
 
     this.server.registerTool(
@@ -205,14 +224,9 @@ class YazioMcpServer {
       {
         description: 'Get user settings and preferences',
         inputSchema: GetUserSettingsInputSchema,
-        annotations: {
-          readOnlyHint: true,
-          idempotentHint: true,
-        },
+        annotations: { readOnlyHint: true, idempotentHint: true },
       },
-      async () => {
-        return await this.getUserSettings();
-      }
+      async () => this.getUserSettings()
     );
 
     this.server.registerTool(
@@ -220,15 +234,9 @@ class YazioMcpServer {
       {
         description: 'Get product suggestions for the user',
         inputSchema: GetUserSuggestedProductsInputSchema,
-        annotations: {
-          readOnlyHint: true,
-          idempotentHint: true,
-          openWorldHint: true,
-        },
+        annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
       },
-      async (args: GetUserSuggestedProductsInput) => {
-        return await this.getUserSuggestedProducts(args);
-      }
+      async (args: GetUserSuggestedProductsInput) => this.getUserSuggestedProducts(args)
     );
 
     this.server.registerTool(
@@ -236,14 +244,9 @@ class YazioMcpServer {
       {
         description: 'Get water intake data for a specific date',
         inputSchema: GetWaterIntakeInputSchema,
-        annotations: {
-          readOnlyHint: true,
-          idempotentHint: true,
-        },
+        annotations: { readOnlyHint: true, idempotentHint: true },
       },
-      async (args: GetWaterIntakeInput) => {
-        return await this.getUserWaterIntake(args);
-      }
+      async (args: GetWaterIntakeInput) => this.getUserWaterIntake(args)
     );
 
     this.server.registerTool(
@@ -251,14 +254,9 @@ class YazioMcpServer {
       {
         description: 'Get user weight data',
         inputSchema: GetUserWeightInputSchema,
-        annotations: {
-          readOnlyHint: true,
-          idempotentHint: true,
-        },
+        annotations: { readOnlyHint: true, idempotentHint: true },
       },
-      async () => {
-        return await this.getUserWeight();
-      }
+      async () => this.getUserWeight()
     );
 
     this.server.registerTool(
@@ -266,63 +264,42 @@ class YazioMcpServer {
       {
         description: 'Get daily nutrition summary for a specific date',
         inputSchema: GetDailySummaryInputSchema,
-        annotations: {
-          readOnlyHint: true,
-          idempotentHint: true,
-        },
+        annotations: { readOnlyHint: true, idempotentHint: true },
       },
-      async (args: GetDailySummaryInput) => {
-        return await this.getUserDailySummary(args);
-      }
+      async (args: GetDailySummaryInput) => this.getUserDailySummary(args)
     );
 
     this.server.registerTool(
       'search_products',
       {
-        description: 'Search for food products in Yazio database. You can optionally specify user\'s sex, country and locale of the products to search for.',
+        description:
+          "Search for food products in Yazio database. You can optionally specify user's sex, country and locale of the products to search for.",
         inputSchema: SearchProductsInputSchema,
-        // outputSchema: SearchProductsOutputSchema,
-        annotations: {
-          readOnlyHint: true,
-          idempotentHint: true,
-          openWorldHint: true,
-        },
+        annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
       },
-      async (args: SearchProductsInput) => {
-        return await this.searchProducts(args);
-      }
+      async (args: SearchProductsInput) => this.searchProducts(args)
     );
 
     this.server.registerTool(
       'search_by_barcode',
       {
-        description: 'Search for a food product by its EAN/UPC barcode number. Searches the Yazio database and filters results by matching EAN code.',
+        description:
+          'Search for a food product by its EAN/UPC barcode number. Searches the Yazio database and filters results by matching EAN code.',
         inputSchema: SearchByBarcodeInputSchema,
-        annotations: {
-          readOnlyHint: true,
-          idempotentHint: true,
-          openWorldHint: true,
-        },
+        annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
       },
-      async (args: SearchByBarcodeInput) => {
-        return await this.searchByBarcode(args);
-      }
+      async (args: SearchByBarcodeInput) => this.searchByBarcode(args)
     );
 
     this.server.registerTool(
       'scan_barcode_image',
       {
-        description: 'Scan a barcode from an image and look up the product in Yazio. Accepts a base64-encoded image, decodes the barcode using zbarimg, and returns the matching product with nutritional info. Use this when you receive a photo of a barcode/product label and need to identify it — no vision model required.',
+        description:
+          'Scan a barcode from an image and look up the product in Yazio. Accepts a base64-encoded image, decodes the barcode using zbarimg, and returns the matching product with nutritional info. Use this when you receive a photo of a barcode/product label and need to identify it — no vision model required.',
         inputSchema: ScanBarcodeImageInputSchema,
-        annotations: {
-          readOnlyHint: true,
-          idempotentHint: true,
-          openWorldHint: true,
-        },
+        annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
       },
-      async (args: ScanBarcodeImageInput) => {
-        return await this.scanBarcodeImage(args);
-      }
+      async (args: ScanBarcodeImageInput) => this.scanBarcodeImage(args)
     );
 
     this.server.registerTool(
@@ -330,15 +307,9 @@ class YazioMcpServer {
       {
         description: 'Get detailed information about a specific product by ID',
         inputSchema: GetProductInputSchema,
-        annotations: {
-          readOnlyHint: true,
-          idempotentHint: true,
-          openWorldHint: true,
-        },
+        annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
       },
-      async (args: GetProductInput) => {
-        return await this.getProduct(args);
-      }
+      async (args: GetProductInput) => this.getProduct(args)
     );
 
     this.server.registerTool(
@@ -346,14 +317,9 @@ class YazioMcpServer {
       {
         description: 'Add a food item to user consumption log',
         inputSchema: AddConsumedItemInputSchema,
-        annotations: {
-          readOnlyHint: false,
-          idempotentHint: false,
-        },
+        annotations: { readOnlyHint: false, idempotentHint: false },
       },
-      async (args: AddConsumedItemInput) => {
-        return await this.addUserConsumedItem(args);
-      }
+      async (args: AddConsumedItemInput) => this.addUserConsumedItem(args)
     );
 
     this.server.registerTool(
@@ -361,32 +327,21 @@ class YazioMcpServer {
       {
         description: 'Remove a food item from user consumption log',
         inputSchema: RemoveConsumedItemInputSchema,
-        annotations: {
-          readOnlyHint: false,
-          destructiveHint: true,
-          idempotentHint: true,
-        },
+        annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
       },
-      async (args: RemoveConsumedItemInput) => {
-        return await this.removeUserConsumedItem(args);
-      }
+      async (args: RemoveConsumedItemInput) => this.removeUserConsumedItem(args)
     );
 
     this.server.registerTool(
       'add_user_water_intake',
       {
-        description: 'Log a water intake entry. Requires date (YYYY-MM-DD HH:mm:ss format) and cumulative water_intake in milliliters (ml). Always get the latest water intake first and add the new amount to calculate the cumulative value.',
+        description:
+          'Log a water intake entry. Requires date (YYYY-MM-DD HH:mm:ss format) and cumulative water_intake in milliliters (ml). Always get the latest water intake first and add the new amount to calculate the cumulative value.',
         inputSchema: AddWaterIntakeInputSchema,
-        annotations: {
-          readOnlyHint: false,
-          idempotentHint: false,
-        },
+        annotations: { readOnlyHint: false, idempotentHint: false },
       },
-      async (args: AddWaterIntakeInput) => {
-        return await this.addUserWaterIntake(args);
-      }
+      async (args: AddWaterIntakeInput) => this.addUserWaterIntake(args)
     );
-
   }
 
   private setupPromptHandlers(): void {
@@ -394,16 +349,15 @@ class YazioMcpServer {
       'add_food_item',
       {
         title: 'Add Food Item to Log',
-        description: 'Guide for adding a food item to the user\'s consumption log',
+        description: "Guide for adding a food item to the user's consumption log",
       },
-      async () => {
-        return {
-          messages: [
-            {
-              role: 'user',
-              content: {
-                type: 'text',
-                text: `To add a food item to the user's consumption log, follow these steps:
+      async () => ({
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: `To add a food item to the user's consumption log, follow these steps:
 
 1. **Search for the product**: Use the \`search_products\` tool with a query string (e.g., "chicken breast", "apple", "pasta"), optionally specifying user's sex, country and locale of the products to search for. This will return a list of matching products with their IDs and short information about the product and serving.
 
@@ -433,29 +387,26 @@ class YazioMcpServer {
 Example:
   1. "I ate 2 apples" - serving type "piece" which has 100g amount (from product details) + serving quantity 2 + amount 200g
   2. "I ate 200g of chicken breast" - amount 200g
-- Always provide amount in base units (g or ml), not in servings.
-`
-              }
-            }
-          ]
-        };
-      }
+- Always provide amount in base units (g or ml), not in servings.`,
+            },
+          },
+        ],
+      })
     );
 
     this.server.registerPrompt(
       'remove_food_item',
       {
         title: 'Remove Food Item from Log',
-        description: 'Guide for removing a food item from the user\'s consumption log',
+        description: "Guide for removing a food item from the user's consumption log",
       },
-      async () => {
-        return {
-          messages: [
-            {
-              role: 'user',
-              content: {
-                type: 'text',
-                text: `To remove a food item from the user's consumption log, follow these steps:
+      async () => ({
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: `To remove a food item from the user's consumption log, follow these steps:
 
 1. **Get consumed items**: Use the \`get_user_consumed_items\` tool with the \`date\` parameter (in YYYY-MM-DD format) to retrieve all food entries for that date.
 
@@ -474,28 +425,26 @@ Example:
 - You must first retrieve the consumed items to get the item ID
 - The \`itemId\` is different from \`product_id\` - use the \`id\` field from the consumed item
 - The date should be in ISO format (YYYY-MM-DD)
-- If multiple items match the description, you may need to ask the user to clarify which specific item to remove`
-              }
-            }
-          ]
-        };
-      }
+- If multiple items match the description, you may need to ask the user to clarify which specific item to remove`,
+            },
+          },
+        ],
+      })
     );
 
     this.server.registerPrompt(
       'add_water_intake',
       {
         title: 'Add Water Intake to Log',
-        description: 'Guide for adding water intake entries to the user\'s log',
+        description: "Guide for adding water intake entries to the user's log",
       },
-      async () => {
-        return {
-          messages: [
-            {
-              role: 'user',
-              content: {
-                type: 'text',
-                text: `To add water intake to the user's log, follow these steps:
+      async () => ({
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: `To add water intake to the user's log, follow these steps:
 
 1. **Get current water intake**: Use the \`get_user_water_intake\` tool with the \`date\` parameter (in YYYY-MM-DD format) to retrieve the current cumulative water intake for that date. The response will contain a \`water_intake\` field with the current cumulative value in milliliters (ml).
 
@@ -518,12 +467,11 @@ Example:
 - Get latest: 500ml
 - Calculate: 500 + 250 = 750ml
 - Call tool with: \`{ date: "2025-12-18 12:00:00", water_intake: 750 }\`
-- The tool sends: \`[{ date: "2025-12-18 12:00:00", water_intake: 750 }]\` to the API`
-              }
-            }
-          ]
-        };
-      }
+- The tool sends: \`[{ date: "2025-12-18 12:00:00", water_intake: 750 }]\` to the API`,
+            },
+          },
+        ],
+      })
     );
   }
 
@@ -534,21 +482,15 @@ Example:
     return this.yazioClient;
   }
 
+  private textResult(text: string) {
+    return { content: [{ type: 'text' as const, text }] };
+  }
 
   private async getUserConsumedItems(args: GetFoodEntriesInput) {
     const client = await this.ensureAuthenticated();
-
     try {
       const foodEntries = await client.user.getConsumedItems({ date: new Date(args.date) });
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Food entries for ${args.date}:\n\n${JSON.stringify(foodEntries, null, 2)}`,
-          },
-        ],
-      };
+      return this.textResult(`Food entries for ${args.date}:\n\n${JSON.stringify(foodEntries, null, 2)}`);
     } catch (error) {
       throw new Error(`Failed to get food entries: ${error}`);
     }
@@ -556,18 +498,9 @@ Example:
 
   private async getUser() {
     const client = await this.ensureAuthenticated();
-
     try {
       const userInfo = await client.user.get();
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `User info:\n\n${JSON.stringify(userInfo, null, 2)}`,
-          },
-        ],
-      };
+      return this.textResult(`User info:\n\n${JSON.stringify(userInfo, null, 2)}`);
     } catch (error) {
       throw new Error(`Failed to get user info: ${error}`);
     }
@@ -575,18 +508,9 @@ Example:
 
   private async getUserDailySummary(args: GetDailySummaryInput) {
     const client = await this.ensureAuthenticated();
-
     try {
       const summary = await client.user.getDailySummary({ date: new Date(args.date) });
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Daily summary for ${args.date}:\n\n${JSON.stringify(summary, null, 2)}`,
-          },
-        ],
-      };
+      return this.textResult(`Daily summary for ${args.date}:\n\n${JSON.stringify(summary, null, 2)}`);
     } catch (error) {
       throw new Error(`Failed to get daily summary: ${error}`);
     }
@@ -594,19 +518,9 @@ Example:
 
   private async getUserWeight() {
     const client = await this.ensureAuthenticated();
-
     try {
-      // Yazio getWeight doesn't support date ranges, just single date
       const weight = await client.user.getWeight();
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `User weight data:\n\n${JSON.stringify(weight, null, 2)}`,
-          },
-        ],
-      };
+      return this.textResult(`User weight data:\n\n${JSON.stringify(weight, null, 2)}`);
     } catch (error) {
       throw new Error(`Failed to get user weight: ${error}`);
     }
@@ -614,18 +528,9 @@ Example:
 
   private async getUserWaterIntake(args: GetWaterIntakeInput) {
     const client = await this.ensureAuthenticated();
-
     try {
       const waterIntake = await client.user.getWaterIntake({ date: new Date(args.date) });
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Water intake for ${args.date}:\n\n${JSON.stringify(waterIntake, null, 2)}`,
-          },
-        ],
-      };
+      return this.textResult(`Water intake for ${args.date}:\n\n${JSON.stringify(waterIntake, null, 2)}`);
     } catch (error) {
       throw new Error(`Failed to get water intake: ${error}`);
     }
@@ -633,135 +538,73 @@ Example:
 
   private async searchProducts(args: SearchProductsInput) {
     const client = await this.ensureAuthenticated();
-
     try {
       const products = await client.products.search(args);
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Products:\n\n${JSON.stringify(products, null, 2)}`,
-          },
-        ],
-        products,
-      };
+      return { ...this.textResult(`Products:\n\n${JSON.stringify(products, null, 2)}`), products };
     } catch (error) {
       throw new Error(`Failed to search products: ${error}`);
     }
   }
 
   private async scanBarcodeImage(args: ScanBarcodeImageInput) {
-    const { execSync } = await import('child_process');
-    const { writeFileSync, unlinkSync } = await import('fs');
-    const { tmpdir } = await import('os');
-    const { join } = await import('path');
-
     // Strip data URL prefix if present
-    let base64Data = args.image;
-    const dataUrlMatch = base64Data.match(/^data:[^;]+;base64,(.+)$/);
-    if (dataUrlMatch) {
-      base64Data = dataUrlMatch[1];
-    }
+    const dataUrlMatch = args.image.match(/^data:[^;]+;base64,(.+)$/);
+    const base64Data = dataUrlMatch ? dataUrlMatch[1] : args.image;
+    const imageBuffer = Buffer.from(base64Data, 'base64');
 
-    // Write base64 image to temp file
-    const tmpFile = join(tmpdir(), `yazio-barcode-${Date.now()}.png`);
+    // Decode image to raw pixel data using sharp or manual PNG parsing
+    let pixelData: { data: Uint8ClampedArray; width: number; height: number };
     try {
-      writeFileSync(tmpFile, Buffer.from(base64Data, 'base64'));
-
-      // Decode barcode using zbarimg
-      let zbarOutput: string;
-      try {
-        zbarOutput = execSync(`zbarimg --raw -q "${tmpFile}"`, {
-          timeout: 10000,
-          encoding: 'utf8',
-        }).trim();
-      } catch (zbarError: any) {
-        // zbarimg exits with code 4 when no barcode found
-        if (zbarError.status === 4) {
-          return {
-            content: [{
-              type: 'text' as const,
-              text: 'No barcode detected in the image. Make sure the barcode is clearly visible and well-lit.',
-            }],
-          };
-        }
-        throw new Error(`zbarimg failed: ${zbarError.message}. Make sure zbarimg is installed (apt-get install zbar-tools).`);
-      }
-
-      // Parse EAN codes (zbarimg can return multiple lines)
-      const codes = zbarOutput.split('\n').filter(Boolean);
-      if (codes.length === 0) {
-        return {
-          content: [{
-            type: 'text' as const,
-            text: 'No barcode detected in the image.',
-          }],
-        };
-      }
-
-      // Search for the first valid barcode
-      const ean = codes[0];
-      const result = await this.searchByBarcode({ ean });
-
-      // Prepend the detected EAN to the result
-      const resultText = result.content[0].text;
-      return {
-        content: [{
-          type: 'text' as const,
-          text: `Detected barcode: ${ean}\n\n${resultText}`,
-        }],
-      };
-    } finally {
-      try { unlinkSync(tmpFile); } catch { /* ignore cleanup errors */ }
+      const { data, info } = await sharp(imageBuffer).ensureAlpha().raw().toBuffer({ resolveWithObject: true });
+      pixelData = { data: new Uint8ClampedArray(data), width: info.width, height: info.height };
+    } catch {
+      throw new Error('Failed to decode image. Make sure sharp is available or the image is valid PNG/JPEG.');
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const results = await readBarcodesFromImageData({ ...pixelData, colorSpace: 'srgb' } as any, {
+      formats: ['EAN-8', 'EAN-13', 'UPC-A', 'UPC-E'],
+    });
+
+    if (results.length === 0) {
+      return this.textResult(
+        'No barcode detected in the image. Make sure the barcode is clearly visible and well-lit.'
+      );
+    }
+
+    const ean = results[0].text;
+    const searchResult = await this.searchByBarcode({ ean });
+    return this.textResult(`Detected barcode: ${ean}\n\n${searchResult.content[0].text}`);
   }
 
   private async searchByBarcode(args: SearchByBarcodeInput) {
     const client = await this.ensureAuthenticated();
-
     try {
-      // Search using EAN as query - Yazio search often matches barcodes
       const products = await client.products.search({ query: args.ean });
 
-      // If we got results, check each product for matching EAN
-      if (products && Array.isArray(products) && products.length > 0) {
-        // Get full details for top results to check EAN fields
+      if (Array.isArray(products) && products.length > 0) {
         const detailedResults = [];
         for (const product of products.slice(0, 5)) {
           try {
             const detail = await client.products.get(product.product_id);
-            if (detail && detail.eans && detail.eans.includes(args.ean)) {
-              detailedResults.push(detail);
-            }
+            if (detail?.eans?.includes(args.ean)) detailedResults.push(detail);
           } catch {
-            // Skip products that fail to fetch
+            /* skip */
           }
         }
 
         if (detailedResults.length > 0) {
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: `Found ${detailedResults.length} product(s) matching barcode ${args.ean}:\n\n${JSON.stringify(detailedResults, null, 2)}`,
-              },
-            ],
-          };
+          return this.textResult(
+            `Found ${detailedResults.length} product(s) matching barcode ${args.ean}:\n\n${JSON.stringify(detailedResults, null, 2)}`
+          );
         }
+
+        return this.textResult(
+          `No exact barcode match found for ${args.ean}, but here are search results:\n\n${JSON.stringify(products, null, 2)}`
+        );
       }
 
-      // Fallback: return search results even without exact EAN match
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: products && Array.isArray(products) && products.length > 0
-              ? `No exact barcode match found for ${args.ean}, but here are search results:\n\n${JSON.stringify(products, null, 2)}`
-              : `No products found for barcode ${args.ean}`,
-          },
-        ],
-      };
+      return this.textResult(`No products found for barcode ${args.ean}`);
     } catch (error) {
       throw new Error(`Failed to search by barcode: ${error}`);
     }
@@ -769,18 +612,9 @@ Example:
 
   private async getProduct(args: GetProductInput) {
     const client = await this.ensureAuthenticated();
-
     try {
       const product = await client.products.get(args.id);
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Product details for ID "${args.id}":\n\n${JSON.stringify(product, null, 2)}`,
-          },
-        ],
-      };
+      return this.textResult(`Product details for ID "${args.id}":\n\n${JSON.stringify(product, null, 2)}`);
     } catch (error) {
       throw new Error(`Failed to get product: ${error}`);
     }
@@ -788,23 +622,11 @@ Example:
 
   private async getUserExercises(args: GetUserExercisesInput) {
     const client = await this.ensureAuthenticated();
-
     try {
       const apiOptions: YazioExerciseOptions = {};
-      if (args.date) {
-        apiOptions.date = args.date;
-      }
-
+      if (args.date) apiOptions.date = args.date;
       const exercises = await client.user.getExercises(apiOptions);
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `User exercises:\n\n${JSON.stringify(exercises, null, 2)}`,
-          },
-        ],
-      };
+      return this.textResult(`User exercises:\n\n${JSON.stringify(exercises, null, 2)}`);
     } catch (error) {
       throw new Error(`Failed to get user exercises: ${error}`);
     }
@@ -812,18 +634,9 @@ Example:
 
   private async getUserSettings() {
     const client = await this.ensureAuthenticated();
-
     try {
       const settings = await client.user.getSettings();
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `User settings:\n\n${JSON.stringify(settings, null, 2)}`,
-          },
-        ],
-      };
+      return this.textResult(`User settings:\n\n${JSON.stringify(settings, null, 2)}`);
     } catch (error) {
       throw new Error(`Failed to get user settings: ${error}`);
     }
@@ -831,22 +644,10 @@ Example:
 
   private async getUserSuggestedProducts(args: GetUserSuggestedProductsInput) {
     const client = await this.ensureAuthenticated();
-
     try {
-      const options: YazioSuggestedProductsOptions = {
-        daytime: 'breakfast',
-        ...args
-      };
+      const options: YazioSuggestedProductsOptions = { daytime: 'breakfast', ...args };
       const suggestions = await client.user.getSuggestedProducts(options);
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Product suggestions:\n\n${JSON.stringify(suggestions, null, 2)}`,
-          },
-        ],
-      };
+      return this.textResult(`Product suggestions:\n\n${JSON.stringify(suggestions, null, 2)}`);
     } catch (error) {
       throw new Error(`Failed to get product suggestions: ${error}`);
     }
@@ -854,21 +655,9 @@ Example:
 
   private async addUserConsumedItem(args: AddConsumedItemInput) {
     const client = await this.ensureAuthenticated();
-
     try {
-      await client.user.addConsumedItem({
-        ...args,
-        id: uuidv4(),
-      });
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Successfully added consumed item`,
-          },
-        ],
-      };
+      await client.user.addConsumedItem({ ...args, id: uuidv4() });
+      return this.textResult('Successfully added consumed item');
     } catch (error) {
       throw new Error(`Failed to add consumed item: ${error}`);
     }
@@ -876,18 +665,11 @@ Example:
 
   private async removeUserConsumedItem(args: RemoveConsumedItemInput) {
     const client = await this.ensureAuthenticated();
-
     try {
       const result = await client.user.removeConsumedItem(args.itemId);
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Successfully removed consumed item with ID: ${args.itemId}\n\n${JSON.stringify(result, null, 2)}`,
-          },
-        ],
-      };
+      return this.textResult(
+        `Successfully removed consumed item with ID: ${args.itemId}\n\n${JSON.stringify(result, null, 2)}`
+      );
     } catch (error) {
       throw new Error(`Failed to remove consumed item: ${error}`);
     }
@@ -895,22 +677,10 @@ Example:
 
   private async addUserWaterIntake(args: AddWaterIntakeInput) {
     const client = await this.ensureAuthenticated();
-
     try {
       // @ts-expect-error - Using monkey-patched method
-      await client.user.addWaterIntake([{
-        date: args.date, // Already in "YYYY-MM-DD HH:mm:ss" format
-        water_intake: args.water_intake,
-      }]);
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Successfully logged water intake entry`,
-          },
-        ],
-      };
+      await client.user.addWaterIntake([{ date: args.date, water_intake: args.water_intake }]);
+      return this.textResult('Successfully logged water intake entry');
     } catch (error) {
       throw new Error(`Failed to add water intake: ${error}`);
     }
@@ -918,18 +688,9 @@ Example:
 
   private async getUserDietaryPreferences() {
     const client = await this.ensureAuthenticated();
-
     try {
       const preferences = await client.user.getDietaryPreferences();
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Dietary preferences:\n\n${JSON.stringify(preferences, null, 2)}`,
-          },
-        ],
-      };
+      return this.textResult(`Dietary preferences:\n\n${JSON.stringify(preferences, null, 2)}`);
     } catch (error) {
       throw new Error(`Failed to get dietary preferences: ${error}`);
     }
@@ -937,23 +698,13 @@ Example:
 
   private async getUserGoals() {
     const client = await this.ensureAuthenticated();
-
     try {
       const goals = await client.user.getGoals({});
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `User goals:\n\n${JSON.stringify(goals, null, 2)}`,
-          },
-        ],
-      };
+      return this.textResult(`User goals:\n\n${JSON.stringify(goals, null, 2)}`);
     } catch (error) {
       throw new Error(`Failed to get user goals: ${error}`);
     }
   }
-
 
   async run(): Promise<void> {
     const transport = new StdioServerTransport();

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ import {
   AddWaterIntakeInputSchema,
   GetDietaryPreferencesInputSchema,
   GetUserGoalsInputSchema,
+  SearchByBarcodeInputSchema,
+  ScanBarcodeImageInputSchema,
   type GetFoodEntriesInput,
   type GetDailySummaryInput,
   type GetWaterIntakeInput,
@@ -34,6 +36,8 @@ import {
   type AddConsumedItemInput,
   type RemoveConsumedItemInput,
   type AddWaterIntakeInput,
+  type SearchByBarcodeInput,
+  type ScanBarcodeImageInput,
 } from './schemas.js';
 import type {
   YazioExerciseOptions,
@@ -290,6 +294,38 @@ class YazioMcpServer {
     );
 
     this.server.registerTool(
+      'search_by_barcode',
+      {
+        description: 'Search for a food product by its EAN/UPC barcode number. Searches the Yazio database and filters results by matching EAN code.',
+        inputSchema: SearchByBarcodeInputSchema,
+        annotations: {
+          readOnlyHint: true,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
+      },
+      async (args: SearchByBarcodeInput) => {
+        return await this.searchByBarcode(args);
+      }
+    );
+
+    this.server.registerTool(
+      'scan_barcode_image',
+      {
+        description: 'Scan a barcode from an image and look up the product in Yazio. Accepts a base64-encoded image, decodes the barcode using zbarimg, and returns the matching product with nutritional info. Use this when you receive a photo of a barcode/product label and need to identify it — no vision model required.',
+        inputSchema: ScanBarcodeImageInputSchema,
+        annotations: {
+          readOnlyHint: true,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
+      },
+      async (args: ScanBarcodeImageInput) => {
+        return await this.scanBarcodeImage(args);
+      }
+    );
+
+    this.server.registerTool(
       'get_product',
       {
         description: 'Get detailed information about a specific product by ID',
@@ -350,6 +386,7 @@ class YazioMcpServer {
         return await this.addUserWaterIntake(args);
       }
     );
+
   }
 
   private setupPromptHandlers(): void {
@@ -611,6 +648,122 @@ Example:
       };
     } catch (error) {
       throw new Error(`Failed to search products: ${error}`);
+    }
+  }
+
+  private async scanBarcodeImage(args: ScanBarcodeImageInput) {
+    const { execSync } = await import('child_process');
+    const { writeFileSync, unlinkSync } = await import('fs');
+    const { tmpdir } = await import('os');
+    const { join } = await import('path');
+
+    // Strip data URL prefix if present
+    let base64Data = args.image;
+    const dataUrlMatch = base64Data.match(/^data:[^;]+;base64,(.+)$/);
+    if (dataUrlMatch) {
+      base64Data = dataUrlMatch[1];
+    }
+
+    // Write base64 image to temp file
+    const tmpFile = join(tmpdir(), `yazio-barcode-${Date.now()}.png`);
+    try {
+      writeFileSync(tmpFile, Buffer.from(base64Data, 'base64'));
+
+      // Decode barcode using zbarimg
+      let zbarOutput: string;
+      try {
+        zbarOutput = execSync(`zbarimg --raw -q "${tmpFile}"`, {
+          timeout: 10000,
+          encoding: 'utf8',
+        }).trim();
+      } catch (zbarError: any) {
+        // zbarimg exits with code 4 when no barcode found
+        if (zbarError.status === 4) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: 'No barcode detected in the image. Make sure the barcode is clearly visible and well-lit.',
+            }],
+          };
+        }
+        throw new Error(`zbarimg failed: ${zbarError.message}. Make sure zbarimg is installed (apt-get install zbar-tools).`);
+      }
+
+      // Parse EAN codes (zbarimg can return multiple lines)
+      const codes = zbarOutput.split('\n').filter(Boolean);
+      if (codes.length === 0) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: 'No barcode detected in the image.',
+          }],
+        };
+      }
+
+      // Search for the first valid barcode
+      const ean = codes[0];
+      const result = await this.searchByBarcode({ ean });
+
+      // Prepend the detected EAN to the result
+      const resultText = result.content[0].text;
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `Detected barcode: ${ean}\n\n${resultText}`,
+        }],
+      };
+    } finally {
+      try { unlinkSync(tmpFile); } catch { /* ignore cleanup errors */ }
+    }
+  }
+
+  private async searchByBarcode(args: SearchByBarcodeInput) {
+    const client = await this.ensureAuthenticated();
+
+    try {
+      // Search using EAN as query - Yazio search often matches barcodes
+      const products = await client.products.search({ query: args.ean });
+
+      // If we got results, check each product for matching EAN
+      if (products && Array.isArray(products) && products.length > 0) {
+        // Get full details for top results to check EAN fields
+        const detailedResults = [];
+        for (const product of products.slice(0, 5)) {
+          try {
+            const detail = await client.products.get(product.product_id);
+            if (detail && detail.eans && detail.eans.includes(args.ean)) {
+              detailedResults.push(detail);
+            }
+          } catch {
+            // Skip products that fail to fetch
+          }
+        }
+
+        if (detailedResults.length > 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Found ${detailedResults.length} product(s) matching barcode ${args.ean}:\n\n${JSON.stringify(detailedResults, null, 2)}`,
+              },
+            ],
+          };
+        }
+      }
+
+      // Fallback: return search results even without exact EAN match
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: products && Array.isArray(products) && products.length > 0
+              ? `No exact barcode match found for ${args.ean}, but here are search results:\n\n${JSON.stringify(products, null, 2)}`
+              : `No products found for barcode ${args.ean}`,
+          },
+        ],
+      };
+    } catch (error) {
+      throw new Error(`Failed to search by barcode: ${error}`);
     }
   }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,46 +1,56 @@
-import * as z from "zod";
+import * as z from 'zod';
 
 export const DaytimeSchema = z.enum(['breakfast', 'lunch', 'dinner', 'snack']);
 export const DateStringSchema = z.iso.date().describe('Date in YYYY-MM-DD format');
 export const ProductIdSchema = z.uuid().describe('Product UUID v1/v4 (e.g. 4ceff6e9-78ce-441b-964a-22e81c1dee92)');
 export const ItemIdSchema = ProductIdSchema.describe('Unique item identifier');
-export const ServingTypeSchema = z.string().describe('Serving type (e.g. portion, fruit, glass, cup, slice, piece, bar, gram, bottle, can, etc.)');
+export const ServingTypeSchema = z
+  .string()
+  .describe('Serving type (e.g. portion, fruit, glass, cup, slice, piece, bar, gram, bottle, can, etc.)');
 
 export const QueryStringSchema = z.string().describe('Search query string');
 export const LimitSchema = z.number().optional().describe('Maximum number of results to return');
 
 export const DateInputSchema = z.object({
-  date: DateStringSchema
+  date: DateStringSchema,
 });
 
 export const OptionalDateInputSchema = z.object({
-  date: DateStringSchema.optional()
+  date: DateStringSchema.optional(),
 });
 
 export const QueryInputSchema = z.object({
   query: QueryStringSchema.describe('Search query'),
-  sex: z.enum(["male", "female"]).default("male").optional(),
-  countries: z.array(z.string()).default(["US"]).optional().describe('Array of country codes for product search (e.g. ["US", "DE", "TR"])'),
-  locales: z.array(z.string()).default(["en_US"]).optional().describe('Array of locale codes (e.g. ["en_US", "de_US"])')
+  sex: z.enum(['male', 'female']).default('male').optional(),
+  countries: z
+    .array(z.string())
+    .default(['US'])
+    .optional()
+    .describe('Array of country codes for product search (e.g. ["US", "DE", "TR"])'),
+  locales: z
+    .array(z.string())
+    .default(['en_US'])
+    .optional()
+    .describe('Array of locale codes (e.g. ["en_US", "de_US"])'),
 });
 
 export const OptionalQueryInputSchema = z.object({
   query: QueryStringSchema.optional().describe('Search query (optional)'),
-  limit: LimitSchema
+  limit: LimitSchema,
 });
 
 export const SearchByBarcodeInputSchema = z.object({
   ean: z.string().describe('EAN/UPC barcode string (e.g. "4005500068709")'),
-  sex: z.enum(["male", "female"]).default("male").optional(),
-  countries: z.array(z.string()).default(["US"]).optional().describe('Array of country codes'),
-  locales: z.array(z.string()).default(["en_US"]).optional().describe('Array of locale codes'),
+  sex: z.enum(['male', 'female']).default('male').optional(),
+  countries: z.array(z.string()).default(['US']).optional().describe('Array of country codes'),
+  locales: z.array(z.string()).default(['en_US']).optional().describe('Array of locale codes'),
 });
 
 export const ScanBarcodeImageInputSchema = z.object({
   image: z.string().describe('Base64-encoded image of a barcode'),
-  sex: z.enum(["male", "female"]).default("male").optional(),
-  countries: z.array(z.string()).default(["US"]).optional().describe('Array of country codes'),
-  locales: z.array(z.string()).default(["en_US"]).optional().describe('Array of locale codes'),
+  sex: z.enum(['male', 'female']).default('male').optional(),
+  countries: z.array(z.string()).default(['US']).optional().describe('Array of country codes'),
+  locales: z.array(z.string()).default(['en_US']).optional().describe('Array of locale codes'),
 });
 
 export const EmptyInputSchema = z.object({});
@@ -52,23 +62,27 @@ export const GetUserWeightInputSchema = EmptyInputSchema; // Yazio getWeight doe
 export const GetWaterIntakeInputSchema = DateInputSchema;
 export const SearchProductsInputSchema = QueryInputSchema;
 export const SearchProductsOutputSchema = z.object({
-  products: z.array(z.object({
-    score: z.number(),
-    name: z.string(),
-    product_id: ProductIdSchema,
-    serving: ServingTypeSchema,
-    serving_quantity: z.number(),
-    amount: z.number(),
-    base_unit: z.enum(['g', 'ml']).describe('Base unit: grams (g) or milliliters (ml)'),
-    producer: z.string().nullable().describe('Producer name'),
-    is_verified: z.boolean(),
-    nutrients: z.record(z.string(), z.number()).describe('Nutrients object with keys like energy.energy, nutrient.carb, etc.'),
-    countries: z.array(z.string()).describe('Array of country codes (e.g. ["US", "DE"])'),
-    language: z.string().describe('Language code (e.g. "en", "de")'),
-  })),
+  products: z.array(
+    z.object({
+      score: z.number(),
+      name: z.string(),
+      product_id: ProductIdSchema,
+      serving: ServingTypeSchema,
+      serving_quantity: z.number(),
+      amount: z.number(),
+      base_unit: z.enum(['g', 'ml']).describe('Base unit: grams (g) or milliliters (ml)'),
+      producer: z.string().nullable().describe('Producer name'),
+      is_verified: z.boolean(),
+      nutrients: z
+        .record(z.string(), z.number())
+        .describe('Nutrients object with keys like energy.energy, nutrient.carb, etc.'),
+      countries: z.array(z.string()).describe('Array of country codes (e.g. ["US", "DE"])'),
+      language: z.string().describe('Language code (e.g. "en", "de")'),
+    })
+  ),
 });
 export const GetProductInputSchema = z.object({
-  id: ProductIdSchema.describe('Product ID to get details for')
+  id: ProductIdSchema.describe('Product ID to get details for'),
 });
 export const GetUserExercisesInputSchema = OptionalDateInputSchema; // Only supports single date, not date ranges
 export const GetUserSettingsInputSchema = EmptyInputSchema;
@@ -80,14 +94,14 @@ export const AddConsumedItemInputSchema = z.object({
   daytime: DaytimeSchema.describe('Type of meal (breakfast, lunch, dinner, snack)'),
   amount: z.number().describe('Amount of the product consumed in base units (g or ml)'),
   serving: ServingTypeSchema.optional(),
-  serving_quantity: z.number().optional().describe('Quantity of servings')
+  serving_quantity: z.number().optional().describe('Quantity of servings'),
 });
 export const RemoveConsumedItemInputSchema = z.object({
-  itemId: ItemIdSchema.describe('ID of the consumed item to remove')
+  itemId: ItemIdSchema.describe('ID of the consumed item to remove'),
 });
 export const AddWaterIntakeInputSchema = z.object({
   date: z.string().describe('Date and time in format "YYYY-MM-DD HH:mm:ss" (e.g., "2025-12-18 12:00:00")'),
-  water_intake: z.number().describe('Cumulative water intake in milliliters (ml)')
+  water_intake: z.number().describe('Cumulative water intake in milliliters (ml)'),
 });
 export const GetDietaryPreferencesInputSchema = EmptyInputSchema;
 export const GetUserGoalsInputSchema = EmptyInputSchema;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -29,6 +29,20 @@ export const OptionalQueryInputSchema = z.object({
   limit: LimitSchema
 });
 
+export const SearchByBarcodeInputSchema = z.object({
+  ean: z.string().describe('EAN/UPC barcode string (e.g. "4005500068709")'),
+  sex: z.enum(["male", "female"]).default("male").optional(),
+  countries: z.array(z.string()).default(["US"]).optional().describe('Array of country codes'),
+  locales: z.array(z.string()).default(["en_US"]).optional().describe('Array of locale codes'),
+});
+
+export const ScanBarcodeImageInputSchema = z.object({
+  image: z.string().describe('Base64-encoded image of a barcode'),
+  sex: z.enum(["male", "female"]).default("male").optional(),
+  countries: z.array(z.string()).default(["US"]).optional().describe('Array of country codes'),
+  locales: z.array(z.string()).default(["en_US"]).optional().describe('Array of locale codes'),
+});
+
 export const EmptyInputSchema = z.object({});
 
 export const GetFoodEntriesInputSchema = DateInputSchema;
@@ -94,3 +108,5 @@ export type RemoveConsumedItemInput = z.infer<typeof RemoveConsumedItemInputSche
 export type AddWaterIntakeInput = z.infer<typeof AddWaterIntakeInputSchema>;
 export type GetDietaryPreferencesInput = z.infer<typeof GetDietaryPreferencesInputSchema>;
 export type GetUserGoalsInput = z.infer<typeof GetUserGoalsInputSchema>;
+export type SearchByBarcodeInput = z.infer<typeof SearchByBarcodeInputSchema>;
+export type ScanBarcodeImageInput = z.infer<typeof ScanBarcodeImageInputSchema>;


### PR DESCRIPTION
## New tools
- `search_by_barcode` — find a product by EAN/UPC code  
- `scan_barcode_image` — decode barcode from base64 image via `zxing-wasm` + `sharp`, then look up in Yazio  

## Token caching
- Persists OAuth token to disk between restarts (configurable via `YAZIO_TOKEN_CACHE_PATH`)  
- Uses `onRefresh` callback to auto-persist refreshed tokens  

## Dependencies
- `zxing-wasm` — barcode decoding (WASM, works everywhere)  
- `sharp` — image decoding to raw pixels  

## Other

- `textResult()` helper to reduce repetition  
- `.prettierrc` printWidth bumped to 120  