### PR TITLE
ci: fix MCP Registry publish (OIDC) and drop always-auth warning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "24.x"
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
@@ -49,7 +48,7 @@ jobs:
       - name: Install MCP Publisher
         continue-on-error: true
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.4.0/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.9/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
       - name: Login to MCP Registry
         continue-on-error: true


### PR DESCRIPTION
## Summary
Two CI fixes to the publish workflow, both surfaced by the `v0.0.14` release run. No code/version change — these only affect the next tag push.

### 1. MCP Registry publish failed (401)
The `v0.0.14` run failed to publish to the MCP Registry:

```
Login to MCP Registry → 401 Unauthorized
invalid audience: expected https://registry.modelcontextprotocol.io, got [mcp-registry]
```

The registry hardened its GitHub OIDC audience in **v1.7.6+** (per [CVE-2026-44428](https://advisories.gitlab.com/golang/github.com/modelcontextprotocol/registry/CVE-2026-44428/)) to be deployment-scoped. The pinned `mcp-publisher v1.4.0` still requests the old `mcp-registry` audience, so login is rejected.

**Fix:** bump `mcp-publisher` `v1.4.0` → `v1.7.9` (latest; asset naming unchanged).

### 2. `npm warn Unknown user config "always-auth"`
`actions/setup-node`'s `registry-url` input writes a deprecated `always-auth` key into the generated `.npmrc` ([setup-node#1305](https://github.com/actions/setup-node/issues/1305)); npm 11 (Node 24) warns on it.

This workflow publishes via **npm OIDC trusted publishing** — there's no `NODE_AUTH_TOKEN` and the job has `id-token: write`, so npm authenticates from the OIDC token, not the `.npmrc` auth line. That makes `registry-url` redundant here.

**Fix:** drop `registry-url` from `setup-node`. npm defaults to `registry.npmjs.org`, so the publish target is unchanged — only the unused auth `.npmrc` (and its warning) goes away.

## Notes
- The MCP Registry steps remain `continue-on-error: true`. The version bump should make them succeed; left as-is so a registry hiccup never blocks an already-completed npm publish + release. Easy to tighten later if you want loud failures.
- Can't be verified until the next `v*` tag triggers the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)